### PR TITLE
0.3.5 - README fixes, flex dependencies

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+v0.3.5, 2014-09-06 remove unsupported badges from README file
 v0.3.4, 2014-09-06 README fixes, no-op on functionality
 v0.3.3, 2014-09-05 Fixed html parser errors (thanks @markmark1)
 v0.3.2, 2014-05-01 Update configparser lib version to 3.5.0b2

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+v0.3.4, 2014-09-06 README fixes, no-op on functionality
 v0.3.3, 2014-09-05 Fixed html parser errors (thanks @markmark1)
 v0.3.2, 2014-05-01 Update configparser lib version to 3.5.0b2
 v0.3.1, 2014-03-16 Update configparser lib version. PyPi version ref had stopped working

--- a/README.rst
+++ b/README.rst
@@ -4,11 +4,6 @@
 .. image:: https://badge.fury.io/py/clippercard.png
     :target: http://badge.fury.io/py/clippercard
 
-.. image:: https://pypip.in/d/clippercard/badge.png
-        :target: https://crate.io/packages/clippercard/
-        
-.. image:: https://pypip.in/license/vxapi/badge.png
-        :target: ./LICENSE
 
 ``clippercard`` is an unofficial web API to clippercard.com, written in Python.
 
@@ -106,7 +101,7 @@ You may toggle accounts via the ``--account`` flag on the command line to access
     username = <replace_with_login_email>
     password = <replace_with_login_password>
     
-The `spare` credentials can then be accessed via::
+The ``spare`` credentials can then be accessed via::
 
     $ clippercard summary --account=spare
 

--- a/clippercard/__init__.py
+++ b/clippercard/__init__.py
@@ -22,4 +22,4 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 import clippercard.client as client
 Session = client.ClipperCardWebSession
 
-__version__ = '0.3.3'
+__version__ = '0.3.4'

--- a/clippercard/__init__.py
+++ b/clippercard/__init__.py
@@ -22,4 +22,4 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 import clippercard.client as client
 Session = client.ClipperCardWebSession
 
-__version__ = '0.3.4'
+__version__ = '0.3.5'

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
 
 setup(
     name='clippercard',
-    version='0.3.4',
+    version='0.3.5',
     author='Unofficial ClipperCard API devs',
     author_email='goldengate88@systemfu.com',
     packages=['clippercard'],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
 
 setup(
     name='clippercard',
-    version='0.3.3',
+    version='0.3.4',
     author='Unofficial ClipperCard API devs',
     author_email='goldengate88@systemfu.com',
     packages=['clippercard'],
@@ -18,14 +18,14 @@ setup(
     },
     scripts=[],
     url='https://github.com/clippercard/clippercard-python',
-    license='LICENSE',
+    license='MIT',
     description='Unofficial Python API for Clipper Card (transportation pass used in the San Francisco Bay Area)',
     long_description=open('README.rst').read(),
     install_requires=[
-        'BeautifulSoup4 >= 4.3.2',
-        'configparser == 3.5.0b2',
-        'docopt >= 0.6.1',
-        'prettytable >= 0.7.2',
-        'requests >= 2.2.1'
+        'BeautifulSoup4>=4.3.2',
+        'configparser>=3.5.0,<4.0',
+        'docopt>=0.6.1,<1.0',
+        'PrettyTable>=0.7.2',
+        'requests>=2.2.1,<3.0'
     ],
 )


### PR DESCRIPTION
1. removing or updating outdated readme/doc elements
1. being flexible with `install_requires` dependencies

# publish log

```
$ python setup.py sdist upload -r pypi
running sdist
running egg_info
writing requirements to clippercard.egg-info/requires.txt
writing clippercard.egg-info/PKG-INFO
writing top-level names to clippercard.egg-info/top_level.txt
writing dependency_links to clippercard.egg-info/dependency_links.txt
writing entry points to clippercard.egg-info/entry_points.txt
reading manifest file 'clippercard.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'clippercard.egg-info/SOURCES.txt'
running check
creating clippercard-0.3.5
creating clippercard-0.3.5/clippercard
creating clippercard-0.3.5/clippercard.egg-info
copying files to clippercard-0.3.5...
copying CHANGES.txt -> clippercard-0.3.5
copying MANIFEST.in -> clippercard-0.3.5
copying README.rst -> clippercard-0.3.5
copying requirements.txt -> clippercard-0.3.5
copying setup.py -> clippercard-0.3.5
copying clippercard/__init__.py -> clippercard-0.3.5/clippercard
copying clippercard/client.py -> clippercard-0.3.5/clippercard
copying clippercard/main.py -> clippercard-0.3.5/clippercard
copying clippercard/parser.py -> clippercard-0.3.5/clippercard
copying clippercard/porcelain.py -> clippercard-0.3.5/clippercard
copying clippercard.egg-info/PKG-INFO -> clippercard-0.3.5/clippercard.egg-info
copying clippercard.egg-info/SOURCES.txt -> clippercard-0.3.5/clippercard.egg-info
copying clippercard.egg-info/dependency_links.txt -> clippercard-0.3.5/clippercard.egg-info
copying clippercard.egg-info/entry_points.txt -> clippercard-0.3.5/clippercard.egg-info
copying clippercard.egg-info/requires.txt -> clippercard-0.3.5/clippercard.egg-info
copying clippercard.egg-info/top_level.txt -> clippercard-0.3.5/clippercard.egg-info
Writing clippercard-0.3.5/setup.cfg
Creating tar archive
removing 'clippercard-0.3.5' (and everything under it)
running upload
Submitting dist/clippercard-0.3.5.tar.gz to https://upload.pypi.org/legacy/
Server response (200): OK
```