### PR TITLE
release 0.4.1 - notes and setup.py version bump

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+v0.4.1, 2018-10-08 Python 3.x fixes, thanks to http://github.com/timroesner
 v0.4.0, 2017-10-02 added support for CalTrain Monthly Passes
 v0.3.5, 2014-09-06 remove unsupported badges from README file
 v0.3.4, 2014-09-06 README fixes, no-op on functionality

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
 
 setup(
     name='clippercard',
-    version='0.4.0',
+    version='0.4.1',
     author='Unofficial ClipperCard API devs',
     author_email='goldengate88@systemfu.com',
     packages=['clippercard'],


### PR DESCRIPTION
Forgot a few administrative items from #5's code review. Fixing before release.

cc: @timroesner - you should see this live on https://pypi.org/project/clippercard/ now.

```
$ make upload-live
python setup.py sdist upload -r pypi
running sdist
running egg_info
writing requirements to clippercard.egg-info/requires.txt
writing clippercard.egg-info/PKG-INFO
writing top-level names to clippercard.egg-info/top_level.txt
writing dependency_links to clippercard.egg-info/dependency_links.txt
writing entry points to clippercard.egg-info/entry_points.txt
reading manifest file 'clippercard.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'clippercard.egg-info/SOURCES.txt'
running check
creating clippercard-0.4.1
creating clippercard-0.4.1/clippercard
creating clippercard-0.4.1/clippercard.egg-info
making hard links in clippercard-0.4.1...
hard linking CHANGES.txt -> clippercard-0.4.1
hard linking MANIFEST.in -> clippercard-0.4.1
hard linking README.rst -> clippercard-0.4.1
hard linking requirements.txt -> clippercard-0.4.1
hard linking setup.py -> clippercard-0.4.1
hard linking clippercard/__init__.py -> clippercard-0.4.1/clippercard
hard linking clippercard/client.py -> clippercard-0.4.1/clippercard
hard linking clippercard/main.py -> clippercard-0.4.1/clippercard
hard linking clippercard/parser.py -> clippercard-0.4.1/clippercard
hard linking clippercard/porcelain.py -> clippercard-0.4.1/clippercard
hard linking clippercard.egg-info/PKG-INFO -> clippercard-0.4.1/clippercard.egg-info
hard linking clippercard.egg-info/SOURCES.txt -> clippercard-0.4.1/clippercard.egg-info
hard linking clippercard.egg-info/dependency_links.txt -> clippercard-0.4.1/clippercard.egg-info
hard linking clippercard.egg-info/entry_points.txt -> clippercard-0.4.1/clippercard.egg-info
hard linking clippercard.egg-info/requires.txt -> clippercard-0.4.1/clippercard.egg-info
hard linking clippercard.egg-info/top_level.txt -> clippercard-0.4.1/clippercard.egg-info
Writing clippercard-0.4.1/setup.cfg
Creating tar archive
removing 'clippercard-0.4.1' (and everything under it)
running upload
Submitting dist/clippercard-0.4.1.tar.gz to https://upload.pypi.org/legacy/
Server response (200): OK
```